### PR TITLE
feat: add GPT 4 Omni model to AI settings

### DIFF
--- a/app/src/lib/ai/types.ts
+++ b/app/src/lib/ai/types.ts
@@ -7,7 +7,8 @@ export enum ModelKind {
 export enum OpenAIModelName {
 	GPT35Turbo = 'gpt-3.5-turbo',
 	GPT4 = 'gpt-4',
-	GPT4Turbo = 'gpt-4-turbo-preview'
+	GPT4Turbo = 'gpt-4-turbo-preview',
+	GPT4o = 'gpt-4o'
 }
 
 export enum AnthropicModelName {

--- a/app/src/lib/components/AISettings.svelte
+++ b/app/src/lib/components/AISettings.svelte
@@ -91,6 +91,10 @@
 		{
 			name: 'GPT 4 Turbo',
 			value: OpenAIModelName.GPT4Turbo
+		},
+		{
+			name: 'GPT 4 Omni',
+			value: OpenAIModelName.GPT4o
 		}
 	];
 

--- a/app/src/routes/settings/ai/+page.svelte
+++ b/app/src/routes/settings/ai/+page.svelte
@@ -100,6 +100,10 @@
 		{
 			name: 'GPT 4 Turbo',
 			value: OpenAIModelName.GPT4Turbo
+		},
+		{
+			name: 'GPT 4 Omni',
+			value: OpenAIModelName.GPT4o
 		}
 	];
 


### PR DESCRIPTION
Add GPT 4 Omni model to the AISettings component, the
OpenAIModelName enumeration, and the +page.svelte file. This enables
users to select the new model in settings.