### PR TITLE
refactor: update Anthropic model names and recommendations

### DIFF
--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -18,10 +18,9 @@ export enum OpenAIModelName {
 
 // https://docs.anthropic.com/en/docs/about-claude/models
 export enum AnthropicModelName {
-	Opus = 'claude-3-opus-20240229',
-	Sonnet = 'claude-3-sonnet-20240229',
-	Haiku = 'claude-3-haiku-20240307',
-	Sonnet35 = 'claude-3-5-sonnet-20240620'
+	Haiku = 'claude-3-5-haiku-latest',
+	Sonnet35 = 'claude-3-5-sonnet-latest',
+	Sonnet37 = 'claude-3-7-sonnet-latest'
 }
 
 export enum MessageRole {

--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -105,21 +105,18 @@
 
 	const anthropicModelOptions = [
 		{
-			label: 'Sonnet',
-			value: AnthropicModelName.Sonnet
-		},
-		{
-			label: 'Opus',
-			value: AnthropicModelName.Opus
-		},
-		{
 			label: 'Haiku',
 			value: AnthropicModelName.Haiku
 		},
 		{
-			label: 'Sonnet 3.5 (recommended)',
+			label: 'Sonnet 3.5',
 			value: AnthropicModelName.Sonnet35
-		}
+		},
+		{
+			label: 'Sonnet 3.7 (recommended)',
+			value: AnthropicModelName.Sonnet37
+		},
+
 	];
 
 	let form = $state<HTMLFormElement>();


### PR DESCRIPTION
## 🧢 Changes

Updates Anthropic model names to use the 'latest' versioning pattern instead of specific dates. Removes the older Opus and Sonnet models while adding the new Sonnet 3.7 model. Updates the UI dropdown to reflect these changes and marks Sonnet 3.7 as the recommended option instead of Sonnet 3.5.



