### PR TITLE
update(ai): show latest openAI models and remove outdated models

### DIFF
--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -9,10 +9,8 @@ export enum ModelKind {
 
 // https://platform.openai.com/docs/models
 export enum OpenAIModelName {
-	GPT35Turbo = 'gpt-3.5-turbo',
-	GPT4 = 'gpt-4',
-	GPT4Turbo = 'gpt-4-turbo',
-	GPT4o = 'gpt-4o',
+	O3mini = 'o3-mini',
+	O1mini = 'o1-mini',
 	GPT4oMini = 'gpt-4o-mini'
 }
 

--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -82,23 +82,15 @@
 
 	const openAIModelOptions = [
 		{
-			label: 'GPT 3.5 Turbo',
-			value: OpenAIModelName.GPT35Turbo
+			label: 'O3 Mini (recommended)',
+			value: OpenAIModelName.O3mini
 		},
 		{
-			label: 'GPT 4',
-			value: OpenAIModelName.GPT4
+			label: 'O1 Mini',
+			value: OpenAIModelName.O1mini
 		},
 		{
-			label: 'GPT 4 Turbo',
-			value: OpenAIModelName.GPT4Turbo
-		},
-		{
-			label: 'GPT 4o',
-			value: OpenAIModelName.GPT4o
-		},
-		{
-			label: 'GPT 4o mini (recommended)',
+			label: 'GPT 4o mini',
 			value: OpenAIModelName.GPT4oMini
 		}
 	];


### PR DESCRIPTION
Replace outdated OpenAI model options with new recommendations and 
simplify naming. Update the display labels for models to improve 
clarity and align with current offerings. Remove obsolete options 
to streamline the selection process.