### PR TITLE
feat: Update AI model option labels

### DIFF
--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -82,11 +82,11 @@
 
 	const openAIModelOptions = [
 		{
-			label: 'O3 Mini (recommended)',
+			label: 'o3 Mini (recommended)',
 			value: OpenAIModelName.O3mini
 		},
 		{
-			label: 'O1 Mini',
+			label: 'o1 Mini',
 			value: OpenAIModelName.O1mini
 		},
 		{


### PR DESCRIPTION
Adjust the labels for OpenAI model options in the settings page to
use lowercase letters for "o3" and "o1" in "o3 Mini" and "o1 Mini"
respectively. This change ensures consistency with official model
naming conventions.