### PR TITLE
feat: update default OpenAI model to O3mini

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -34,7 +34,7 @@ import type { SecretsService } from '$lib/secrets/secretsService';
 const defaultGitConfig = Object.freeze({
 	[GitAIConfigKey.ModelProvider]: ModelKind.OpenAI,
 	[GitAIConfigKey.OpenAIKeyOption]: KeyOption.ButlerAPI,
-	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT35Turbo,
+	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.O3mini,
 	[GitAIConfigKey.AnthropicKeyOption]: KeyOption.ButlerAPI,
 	[GitAIConfigKey.AnthropicModelName]: AnthropicModelName.Haiku
 });

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -123,7 +123,7 @@ export class AIService {
 	async getOpenAIModleName() {
 		return await this.gitConfig.getWithDefault<OpenAIModelName>(
 			GitAIConfigKey.OpenAIModelName,
-			OpenAIModelName.GPT35Turbo
+			OpenAIModelName.O3mini
 		);
 	}
 


### PR DESCRIPTION
Updates the default OpenAI model from GPT-3.5-Turbo to O3mini in
both the AIService and the default GitConfig for tests. This change
aligns the application with the latest preferred model for improved
performance and efficiency.