### PR TITLE
feat: change default AI model to GPT 4o mini

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -34,7 +34,7 @@ import type { SecretsService } from '$lib/secrets/secretsService';
 const defaultGitConfig = Object.freeze({
 	[GitAIConfigKey.ModelProvider]: ModelKind.OpenAI,
 	[GitAIConfigKey.OpenAIKeyOption]: KeyOption.ButlerAPI,
-	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.O3mini,
+	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT4oMini,
 	[GitAIConfigKey.AnthropicKeyOption]: KeyOption.ButlerAPI,
 	[GitAIConfigKey.AnthropicModelName]: AnthropicModelName.Haiku
 });

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -123,7 +123,7 @@ export class AIService {
 	async getOpenAIModleName() {
 		return await this.gitConfig.getWithDefault<OpenAIModelName>(
 			GitAIConfigKey.OpenAIModelName,
-			OpenAIModelName.O3mini
+			OpenAIModelName.GPT4oMini
 		);
 	}
 

--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -82,7 +82,7 @@
 
 	const openAIModelOptions = [
 		{
-			label: 'o3 Mini (recommended)',
+			label: 'o3 Mini',
 			value: OpenAIModelName.O3mini
 		},
 		{
@@ -90,7 +90,7 @@
 			value: OpenAIModelName.O1mini
 		},
 		{
-			label: 'GPT 4o mini',
+			label: 'GPT 4o mini (recommended)',
 			value: OpenAIModelName.GPT4oMini
 		}
 	];


### PR DESCRIPTION
Updates the default OpenAI model from o3 Mini to GPT 4o mini and
marks it as the recommended option in the UI. This change reflects
our current recommendation for the best balance of performance and
capabilities for users.