### PR TITLE
fix: update openAI API parameter name

### DIFF
--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -25,7 +25,7 @@ export class OpenAIClient implements AIClient {
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
 		const response = await this.client.chat.completions.create({
-			max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+			max_completion_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
 			messages: prompt,
 			model: this.modelName,
 			stream: true

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -24,6 +24,10 @@ export class OpenAIClient implements AIClient {
 	}
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
+		// The 'max_tokens' parameter has been renamed to 'max_completion_tokens' in the OpenAI API.
+		// This change aligns with the updated API specification where 'max_completion_tokens'
+		// specifically controls the maximum number of tokens for the completion portion of the response.
+		// https://platform.openai.com/docs/api-reference/completions/create
 		const response = await this.client.chat.completions.create({
 			max_completion_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
 			messages: prompt,


### PR DESCRIPTION
Update the parameter name from 'max_tokens' to 'max_completion_tokens'
in the OpenAIClient's evaluate method to align with changes in the 
OpenAI API. The parameter now specifically controls the maximum
number of tokens for the completion portion of the response rather
than the total tokens.