### PR TITLE
feat: add Claude Sonnet 4 and Opus 4 model options

### DIFF
--- a/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
@@ -114,6 +114,14 @@
 		{
 			label: 'Sonnet 3.7 (recommended)',
 			value: AnthropicModelName.Sonnet37
+		},
+		{
+			label: 'Sonnet 4',
+			value: AnthropicModelName.Sonnet4
+		},
+		{
+			label: 'Opus 4',
+			value: AnthropicModelName.Opus4
 		}
 	];
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -15,11 +15,13 @@ export enum OpenAIModelName {
 	GPT4oMini = 'gpt-4o-mini'
 }
 
-// https://docs.anthropic.com/en/docs/about-claude/models
+// https://docs.anthropic.com/en/docs/about-claude/models/overview
 export enum AnthropicModelName {
 	Haiku = 'claude-3-5-haiku-latest',
 	Sonnet35 = 'claude-3-5-sonnet-latest',
-	Sonnet37 = 'claude-3-7-sonnet-latest'
+	Sonnet37 = 'claude-3-7-sonnet-latest',
+	Sonnet4 = 'claude-sonnet-4-0',
+	Opus4 = 'claude-opus-4-0'
 }
 
 export enum MessageRole {


### PR DESCRIPTION
Add support for the latest Anthropic Claude 4 models in AI settings.
Update model enum to include claude-sonnet-4-0 and claude-opus-4-0,
and expose them as selectable options in the profile settings UI.