### PR TITLE
feat: update Anthropic models and add latest versions

### DIFF
--- a/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
@@ -122,6 +122,14 @@
 		{
 			label: 'Opus 4',
 			value: AnthropicModelName.Opus4
+		},
+		{
+			label: 'Sonnet 4 Latest',
+			value: AnthropicModelName.SonnetLatest
+		},
+		{
+			label: 'Opus 4 Latest',
+			value: AnthropicModelName.OpusLatest
 		}
 	];
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -17,11 +17,13 @@ export enum OpenAIModelName {
 
 // https://docs.anthropic.com/en/docs/about-claude/models/overview
 export enum AnthropicModelName {
-	Haiku = 'claude-3-5-haiku-latest',
-	Sonnet35 = 'claude-3-5-sonnet-latest',
-	Sonnet37 = 'claude-3-7-sonnet-latest',
-	Sonnet4 = 'claude-sonnet-4-0',
-	Opus4 = 'claude-opus-4-0'
+	Haiku = 'claude-3-5-haiku-20241022',
+	Sonnet35 = 'claude-3-5-sonnet-20241022',
+	Sonnet37 = 'claude-3-7-sonnet-20250219',
+	Sonnet4 = 'claude-sonnet-4-20250514',
+	Opus4 = 'claude-opus-4-20250514',
+	SonnetLatest = 'claude-sonnet-4-0',
+	OpusLatest = 'claude-opus-4-0'
 }
 
 export enum MessageRole {


### PR DESCRIPTION
Update Anthropic model names to use versioned strings instead of 
'latest' for better stability. Add new options for latest versions of 
Sonnet 4 and Opus 4 models in the AI settings dropdown to give users 
the choice between pinned or latest versions.