### PR TITLE
fix: correct spelling of "determined" in forge form

### DIFF
--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -90,8 +90,8 @@
 		</Select>
 	{:else}
 		<p class="text-13">
-			We have determiend that you are currently using <code>{$determinedForgeType}</code>. We
-			currently do not support overriding an automatically determiend forge type.
+			We have determined that you are currently using <code>{$determinedForgeType}</code>. We
+			currently do not support overriding an automatically determined forge type.
 		</p>
 	{/if}
 </SectionCard>


### PR DESCRIPTION
Fix typo where "determiend" was misspelled as "determined" in the
forge type override message. This improves the user-facing text
clarity and professionalism.