### PR TITLE
feat: update Anthropic models to latest versions

### DIFF
--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -129,20 +129,16 @@
 			value: AnthropicModelName.Haiku,
 		},
 		{
-			label: "Sonnet 3.5",
-			value: AnthropicModelName.Sonnet35,
+			label: "Sonnet 4.6 (recommended)",
+			value: AnthropicModelName.Sonnet46,
 		},
 		{
-			label: "Sonnet 3.7 (recommended)",
-			value: AnthropicModelName.Sonnet37,
+			label: "Opus 4.6",
+			value: AnthropicModelName.Opus46,
 		},
 		{
-			label: "Sonnet 4",
-			value: AnthropicModelName.Sonnet4,
-		},
-		{
-			label: "Opus 4",
-			value: AnthropicModelName.Opus4,
+			label: "Opus 4.5",
+			value: AnthropicModelName.Opus45,
 		},
 	];
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -20,12 +20,12 @@ export enum OpenAIModelName {
 }
 
 // https://docs.anthropic.com/en/docs/about-claude/models/overview
+// https://platform.claude.com/docs/en/about-claude/model-deprecations#model-status (show active models only)
 export enum AnthropicModelName {
-	Haiku = "claude-3-5-haiku-20241022",
-	Sonnet35 = "claude-3-5-sonnet-20241022",
-	Sonnet37 = "claude-3-7-sonnet-20250219",
-	Sonnet4 = "claude-sonnet-4-0",
-	Opus4 = "claude-opus-4-0",
+	Haiku = "claude-haiku-4-5-20251001",
+	Sonnet46 = "claude-sonnet-4-6",
+	Opus46 = "claude-opus-4-6",
+	Opus45 = "claude-opus-4-5-20251101",
 }
 
 export enum MessageRole {


### PR DESCRIPTION
Update the Anthropic model enum and UI labels to reflect
the current active models from Claude's model status page.

- Replace Claude 3.5/3.7 Sonnet and Sonnet/Opus 4 with
  Sonnet 4.6, Opus 4.6, and Opus 4.5
- Update Haiku to claude-haiku-4-5-20251001
- Set Sonnet 4.6 as the new recommended model
- Add reference to model deprecations documentation to
  ensure only active models are listed